### PR TITLE
[feat] 임시 검색어 순위 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
@@ -41,7 +42,7 @@ dependencies {
 
     // Map Struct
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
-    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.0'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 }
 

--- a/src/main/java/dev/ioexception/community/controller/ArticleController.java
+++ b/src/main/java/dev/ioexception/community/controller/ArticleController.java
@@ -81,4 +81,11 @@ public class ArticleController {
 
         return ResponseEntity.ok(list);
     }
+
+    @GetMapping("/realtime")
+    public ResponseEntity<String> getRealTimeKeyword() throws IOException {
+        String s = articleServiceES.Top10Keyword();
+
+        return ResponseEntity.ok(s);
+    }
 }

--- a/src/main/java/dev/ioexception/community/log/LoggingAspect.java
+++ b/src/main/java/dev/ioexception/community/log/LoggingAspect.java
@@ -1,0 +1,38 @@
+package dev.ioexception.community.log;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class LoggingAspect {
+    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+
+    @Pointcut("execution(* dev.ioexception.community.controller.ArticleController.searchArticle(..))")
+    public void searchArticle() { }
+
+    @Around("searchArticle()")
+    public Object logSearchArticle(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+        String queryField = (String) args[0];
+        String queryKeyword = (String) args[1];
+
+        long startTime = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long executionTime = System.currentTimeMillis() - startTime;
+
+        String logMessage = String.format(
+                "ES_METRIC query.requests=%s, query.question=%s, query.execution.time=%d, timestamp=%d",
+                queryField, queryKeyword, executionTime, System.currentTimeMillis()
+        );
+
+        logger.info(logMessage);
+
+        return result;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,3 +39,21 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+
+logging:
+  level:
+    org:
+      elasticsearch:
+        client: debug
+      springframework:
+        data:
+          elasticsearch:
+            client: debug
+      hibernate:
+        type:
+          descriptor:
+            sql: trace
+    root: info
+    dev.ioexception: info
+  file:
+    name: "${log.file.name}"


### PR DESCRIPTION
- 로컬 캐시와 STOMP를 이용한 구현으로 변경 예정
  - 스케줄링을 이용하여 일정시간 마다 검색 순위 갱신
  - 새로 집계된 검색 순위 로컬 캐시 저장
  - 클라이언트에서 요청 있을 시 로컬 캐시에서 반환